### PR TITLE
feat(devoluciones): add logic to update loan status when all equipmen…

### DIFF
--- a/ajax/devoluciones.ajax.php
+++ b/ajax/devoluciones.ajax.php
@@ -23,14 +23,18 @@ class AjaxDevoluciones {
     =============================================*/
     public function ajaxMarcarMantenimientoDetalle() {
         // No se necesita pasar id_estado desde aquí, ya que se define en el controlador
-        $respuestaModelo = ControladorDevoluciones::ctrMarcarMantenimientoDetalle($this->idPrestamo, $this->idEquipo);
+        $respuestaControlador = ControladorDevoluciones::ctrMarcarMantenimientoDetalle($this->idPrestamo, $this->idEquipo);
         
-        if ($respuestaModelo == "ok") {
-            echo json_encode(array("success" => true, "message" => "Equipo marcado para mantenimiento correctamente."));
-        } else if ($respuestaModelo == "no_change") {
-            echo json_encode(array("success" => false, "message" => "El equipo ya estaba en el estado deseado o no se encontró."));
-        } else {
-            echo json_encode(array("success" => false, "message" => "Error al actualizar el estado del equipo en el modelo."));
+        if ($respuestaControlador == "ok") {
+            echo json_encode(array("success" => true, "status" => "equipo_marcado", "message" => "Equipo marcado para mantenimiento correctamente."));
+        } else if ($respuestaControlador == "ok_prestamo_actualizado") {
+            echo json_encode(array("success" => true, "status" => "prestamo_actualizado", "message" => "Equipo marcado y préstamo actualizado a devuelto."));
+        } else if ($respuestaControlador == "no_change") {
+            echo json_encode(array("success" => false, "status" => "sin_cambios", "message" => "El equipo ya estaba en el estado deseado o no se encontró."));
+        } else if ($respuestaControlador == "error_actualizando_prestamo") {
+            echo json_encode(array("success" => false, "status" => "error_prestamo", "message" => "Equipo marcado, pero hubo un error al actualizar el préstamo."));
+        } else { // Cubre el caso 'error' del marcado inicial y cualquier otro inesperado
+            echo json_encode(array("success" => false, "status" => "error_marcado", "message" => "Error al actualizar el estado del equipo."));
         }
     }
 }

--- a/controladores/devoluciones.controlador.php
+++ b/controladores/devoluciones.controlador.php
@@ -21,9 +21,26 @@
 					   "equipo_id" => $idEquipo,
 					   "id_estado" => 4); // Cambiado de "estado" => "Mantenimiento"
 
-		$respuesta = ModeloDevoluciones::mdlMarcarMantenimientoDetalle($tabla, $datos);
+		$respuestaMarcado = ModeloDevoluciones::mdlMarcarMantenimientoDetalle($tabla, $datos);
 
-		return $respuesta;
+		if($respuestaMarcado == "ok"){
+			// Verificar si todos los equipos del préstamo han sido devueltos
+			$todosDevueltos = ModeloDevoluciones::mdlVerificarTodosEquiposDevueltos($idPrestamo);
+
+			if($todosDevueltos){
+				// Si todos han sido devueltos, actualizar el estado del préstamo
+				$respuestaActualizacionPrestamo = ModeloDevoluciones::mdlActualizarPrestamoDevuelto($idPrestamo);
+				if($respuestaActualizacionPrestamo == "ok"){
+					return "ok_prestamo_actualizado"; // Éxito al marcar equipo y actualizar préstamo
+				} else {
+					return "error_actualizando_prestamo"; // Error al actualizar el préstamo
+				}
+			} else {
+				return "ok"; // Éxito al marcar el equipo, pero no todos han sido devueltos aún
+			}
+		} else {
+			return $respuestaMarcado; // Retorna "no_change" o "error" del marcado inicial
+		}
 
 	}
 

--- a/modelos/devoluciones.modelo.php
+++ b/modelos/devoluciones.modelo.php
@@ -91,4 +91,51 @@ class ModeloDevoluciones
 
 	 } 
 
+	/*============================================= 
+	VERIFICAR SI TODOS LOS EQUIPOS DE UN PRÉSTAMO HAN SIDO DEVUELTOS (MARCADOS PARA MANTENIMIENTO)
+	=============================================*/
+	static public function mdlVerificarTodosEquiposDevueltos($idPrestamo){
+
+		$stmt = Conexion::conectar()->prepare(
+			"SELECT COUNT(*) as total_equipos, 
+					SUM(CASE WHEN id_estado = 4 THEN 1 ELSE 0 END) as equipos_en_mantenimiento 
+			 FROM detalle_prestamo 
+			 WHERE id_prestamo = :id_prestamo"
+		);
+
+		$stmt->bindParam(":id_prestamo", $idPrestamo, PDO::PARAM_INT);
+		$stmt->execute();
+		$resultado = $stmt->fetch(PDO::FETCH_ASSOC);
+
+		if($resultado && $resultado["total_equipos"] > 0 && $resultado["total_equipos"] == $resultado["equipos_en_mantenimiento"]){
+			return true; // Todos los equipos están en mantenimiento
+		} else {
+			return false; // No todos los equipos están en mantenimiento o no hay equipos
+		}
+
+		$stmt = null;
+	}
+
+	/*=============================================
+	ACTUALIZAR ESTADO DEL PRÉSTAMO A DEVUELTO Y REGISTRAR FECHA REAL DE DEVOLUCIÓN
+	=============================================*/
+	static public function mdlActualizarPrestamoDevuelto($idPrestamo){
+
+		$stmt = Conexion::conectar()->prepare(
+			"UPDATE prestamos 
+			 SET estado_prestamo = 'Devuelto', fecha_devolucion_real = NOW() 
+			 WHERE id_prestamo = :id_prestamo"
+		);
+
+		$stmt->bindParam(":id_prestamo", $idPrestamo, PDO::PARAM_INT);
+
+		if($stmt->execute()){
+			return "ok";
+		} else {
+			return "error";
+		}
+
+		$stmt = null;
+	}
+
 }

--- a/vistas/js/devoluciones.js
+++ b/vistas/js/devoluciones.js
@@ -199,3 +199,100 @@ $(document).ready(function() {
         }
     });
 });
+
+/*=============================================            
+Marcar equipo como devuelto
+=============================================*/
+
+$(".tablaDevoluciones tbody").on("click", ".btnMarcarDevuelto", function(){
+
+    var idDetallePrestamo = $(this).attr("idDetallePrestamo");
+    var idPrestamo = $(this).attr("idPrestamo"); // Asegúrate de que este atributo se esté pasando correctamente
+
+    console.log("idDetallePrestamo", idDetallePrestamo);
+    console.log("idPrestamo", idPrestamo);
+
+    Swal.fire({
+        title: '¿Está seguro de marcar este equipo como devuelto?',
+        text: "¡Si no lo está puede cancelar la acción!",
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#3085d6',
+        cancelButtonColor: '#d33',
+        confirmButtonText: 'Sí, marcar devuelto!',
+        cancelButtonText: 'Cancelar'
+    }).then((result) => {
+        if (result.isConfirmed) {
+
+            var datos = new FormData();
+            datos.append("idDetallePrestamoMarcar", idDetallePrestamo);
+            datos.append("idPrestamoMarcar", idPrestamo); // Enviar también idPrestamo
+
+            $.ajax({
+                url: "ajax/devoluciones.ajax.php",
+                method: "POST",
+                data: datos,
+                cache: false,
+                contentType: false,
+                processData: false,
+                dataType: "json", // Esperamos una respuesta JSON
+                success: function(respuesta){
+                    console.log("Respuesta AJAX:", respuesta);
+                    if(respuesta.status == "success_prestamo_actualizado"){
+                        Swal.fire(
+                            '¡Hecho!',
+                            'El equipo ha sido marcado como devuelto y el préstamo ha sido actualizado.',
+                            'success'
+                        ).then((result) => {
+                            if (result.isConfirmed) {
+                                window.location = "devoluciones";
+                            }
+                        });
+                    } else if (respuesta.status == "success"){
+                        Swal.fire(
+                            '¡Hecho!',
+                            'El equipo ha sido marcado como devuelto.',
+                            'success'
+                        ).then((result) => {
+                            if (result.isConfirmed) {
+                                window.location = "devoluciones";
+                            }
+                        });
+                    } else if (respuesta.status == "no_change"){
+                        Swal.fire(
+                            'Información',
+                            'No se realizaron cambios en el estado del equipo.',
+                            'info'
+                        );
+                    } else if (respuesta.status == "error_actualizando_prestamo"){
+                        Swal.fire(
+                            'Error',
+                            'El equipo fue marcado como devuelto, pero hubo un error al actualizar el estado del préstamo.',
+                            'error'
+                        );
+                    } else if (respuesta.status == "error"){
+                        Swal.fire(
+                            'Error',
+                            'No se pudo marcar el equipo como devuelto.',
+                            'error'
+                        );
+                    } else {
+                        Swal.fire(
+                            'Error',
+                            'Respuesta desconocida del servidor.',
+                            'error'
+                        );
+                    }
+                },
+                error: function(jqXHR, textStatus, errorThrown) {
+                    console.error("Error en AJAX: ", textStatus, errorThrown);
+                    Swal.fire(
+                        'Error de Comunicación',
+                        'No se pudo conectar con el servidor: ' + textStatus,
+                        'error'
+                    );
+                }
+            });
+        }
+    })
+})


### PR DESCRIPTION
…t is returned

This commit introduces new functionality to automatically update the loan status to "Devuelto" (Returned) when all associated equipment is marked for maintenance. It includes:
- A method to verify if all equipment in a loan is returned.
- A method to update the loan status and set the return date.
- Enhanced AJAX responses to handle different scenarios (success, no change, errors).
- Updated JavaScript to handle the new responses and display appropriate messages to the user.